### PR TITLE
Mention MetaProvides::Package in pod

### DIFF
--- a/lib/Dist/Zilla/PluginBundle/SCHWIGON.pm
+++ b/lib/Dist/Zilla/PluginBundle/SCHWIGON.pm
@@ -32,6 +32,7 @@ It is roughly equivalent to:
 
   [MetaConfig]
   [MetaJSON]
+  [MetaProvides::Package]
   [PkgVersion]
   [PodSyntaxTests]
   [PodCoverageTests]


### PR DESCRIPTION
Looks like it's added, but never mentioned in document.